### PR TITLE
Add user and bucket list metadata endpoints

### DIFF
--- a/RadosGW.AdminAPI/RadosGWAdminConnection.cs
+++ b/RadosGW.AdminAPI/RadosGWAdminConnection.cs
@@ -556,5 +556,16 @@ namespace Radosgw.AdminAPI
             return SendRequest("DELETE", "/user?key", req, timeout);
         }
 
+        public async Task<IList<string>> ListUsersAsync(TimeSpan? timeout = null)
+        {
+            var rets = await SendRequestAsync("GET", "/metadata/user", timeout: timeout);
+            return JsonConvert.DeserializeObject<IList<string>>(rets);
+        }
+
+        public async Task<IList<string>> ListBucketsAsync(TimeSpan? timeout = null)
+        {
+            var rets = await SendRequestAsync("GET", "/metadata/bucket", timeout: timeout);
+            return JsonConvert.DeserializeObject<IList<string>>(rets);
+        }
     }
 }


### PR DESCRIPTION
Rados contains metadata endpoints to allow API consumers to list all buckets and UIDs.  This is helpful to compare the state of the cluster to a known state.

Let me know if you have any questions.